### PR TITLE
add option to fail on uncaught errors

### DIFF
--- a/angular-test-runner.js
+++ b/angular-test-runner.js
@@ -27038,7 +27038,9 @@ var _ = require('lodash');
 
 module.exports = app;
 
-function app(modules){
+function app(modules, config){
+
+  config = _.defaults(config, {failOnUncaughtErrors : false});
 
   return {
     run: _.partial(run, _, _, true),
@@ -27054,7 +27056,7 @@ function app(modules){
       modulesToLoad = modulesToLoad.concat(html);
     }
     
-    angular.module('test-app', modulesToLoad)
+    var module = angular.module('test-app', modulesToLoad)
       .directive('testApp', function(){
         var d = {
           restrict: 'A'
@@ -27069,6 +27071,14 @@ function app(modules){
       .run(function($rootScope){
         _.assign($rootScope, scope);
       });
+    if(config.failOnUncaughtErrors) {
+      module
+        .factory('$exceptionHandler', function () {
+          return function failTest(error) {
+            fail(error);
+          };
+        });
+    }
 
     var compile, scope, actions = [];
 

--- a/src/angular-test-runner.js
+++ b/src/angular-test-runner.js
@@ -2,7 +2,9 @@ var _ = require('lodash');
 
 module.exports = app;
 
-function app(modules){
+function app(modules, config){
+
+  config = _.defaults(config, {failOnUncaughtErrors : false});
 
   return {
     run: _.partial(run, _, _, true),
@@ -18,7 +20,7 @@ function app(modules){
       modulesToLoad = modulesToLoad.concat(html);
     }
     
-    angular.module('test-app', modulesToLoad)
+    var module = angular.module('test-app', modulesToLoad)
       .directive('testApp', function(){
         var d = {
           restrict: 'A'
@@ -33,6 +35,14 @@ function app(modules){
       .run(function($rootScope){
         _.assign($rootScope, scope);
       });
+    if(config.failOnUncaughtErrors) {
+      module
+        .factory('$exceptionHandler', function () {
+          return function failTest(error) {
+            fail(error);
+          };
+        });
+    }
 
     var compile, scope, actions = [];
 


### PR DESCRIPTION
This option will fail a test if any uncaught error is thrown asynchronously. It won't fail always (that's why there is no test for it), because some simple tests will end before any error gets a chance to be thrown.

Convenient but not very reliable, so turned off by default.